### PR TITLE
Closes #25: Museum data link in dropdown doesn't open link

### DIFF
--- a/app/scripts/views/home/home-partial.html
+++ b/app/scripts/views/home/home-partial.html
@@ -11,11 +11,11 @@
                     <div class="dropdown" dropdown>
                         <span class="dropdown-toggle" dropdown-toggle>
                             Download Museum Info <i class="md-icon-down-mini"></i>
-                            <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
-                                <li role="menuitem"><a href="http://www.imls.gov/research/museum_universe_data_file.aspx" target="_blank">Full Report</a></li>
-                                <li role="menuitem"><a ng-click="home.onDownloadRowClicked()">Museum Row</a></li>
-                            </ul>
                         </span>
+                        <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
+                            <li role="menuitem"><a href="http://www.imls.gov/research/museum_universe_data_file.aspx" target="_blank">Full Report</a></li>
+                            <li role="menuitem"><a ng-click="home.onDownloadRowClicked()">Museum Row</a></li>
+                        </ul>
                     </div>
                 </div>
                 <div ng-class="{


### PR DESCRIPTION
The dropdown list was inside the dropdown-toggle element,
which masked events within the dropdown list.

@designmatty this will need to be restyled a bit.