### PR TITLE
Closes #67: Monkeypatch Leaflet.draw to only return distance in mi

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -21,6 +21,20 @@
         $rootScope.$on('$stateChangeSuccess', function () {
             $window.scrollTo(0,0);
         });
+
+
+        // monkeypatch leaflet draw
+        L.GeometryUtil.readableArea = function (area) {
+            // bypass all metric/yds/acres/miles logic and just return
+            // square miles
+            area /= 0.836127; // Square yards in 1 meter
+            return (area / 3097600).toFixed(2) + ' mi&sup2;';
+        };
+        L.GeometryUtil.readableDistance = function (distance) {
+            // just return miles
+            distance *= 1.09361; // to yards
+            return (distance / 1760).toFixed(2) + ' miles';
+        };
     }
 
     /**


### PR DESCRIPTION
Leaflet.draw includes a metric option that can be set to false, but will display yards when drawing a circle if the radius is less than 1 mi.

This forces Leaflet.draw to always show the mi unit. I have verified that it works after a `grunt build`.