### PR TITLE
fixed a bug on firefox where the nav logo container was too large

### DIFF
--- a/app/styles/components/_brand.scss
+++ b/app/styles/components/_brand.scss
@@ -7,6 +7,7 @@
 	z-index: 10;
     margin-top: -5px;
     margin-bottom: -5px;
+    max-width: 260px; // firefox bug fix
 
     &:after {
         content: 'beta';


### PR DESCRIPTION
before: 
<img width="963" alt="screen shot 2015-10-08 at 3 06 26 pm" src="https://cloud.githubusercontent.com/assets/1928955/10376857/2fa350dc-6dce-11e5-8c0c-50c02ab7d723.png">


After: 
<img width="1008" alt="screen shot 2015-10-08 at 3 05 45 pm" src="https://cloud.githubusercontent.com/assets/1928955/10376861/3528ae8a-6dce-11e5-9ea3-341cf794af81.png">
