### PR TITLE
Fix tooltip hover conflicts

### DIFF
--- a/app/scripts/map/cartodb-vis-directive.js
+++ b/app/scripts/map/cartodb-vis-directive.js
@@ -80,6 +80,8 @@
                     ctl.sublayers = layer.getSubLayers();
                     ctl.onSublayerChange(ctl.sublayers[-1]);
                     $scope.$apply();
+
+                    layer.on('featureOver', onDemographicsLayerFeatureOver);
                 });
             }
 
@@ -114,6 +116,12 @@
         function onPointsLayerFeatureOver() {
             if (demographicsVisible) {
                 $('div.cartodb-tooltip .tooltip-points').parent().css('display', 'none');
+            }
+        }
+
+        function onDemographicsLayerFeatureOver() {
+            if (demographicsVisible) {
+                $('div.cartodb-tooltip .tooltip-tracts').parent().css('display', 'block');
             }
         }
     }


### PR DESCRIPTION
If one of the demographic layers is active, show the hover
tooltip for that layer, otherwise show the points tooltip on hover.
The point layer click action should be unaffected.

This fixes by listening to the featureOver event of the points layer
and re-adding the display:none class to its tooltip element after
cartodbjs has made it visible.

This required adding 'tooltip-tracts' and 'tooltip-points' classes
to each of the custom HTML templates in the cartodb visualizations.

Other attempted fixes:

  - Disable tooltips and use custom vis.addOverlay() along with
    sublayer.setInteractivity to display the tooltips. Then toggle
    tooltips with tooltip.enable() and tooltip.disable(). Could
    not get tooltips to display.
  - Disable layer interaction using sublayer.setInteraction().
    Had no effect.
  - Manually set the existing tooltip visibility in onSublayerChange
    based on whether a demographics layer is selected. The tooltip
    dynamically overwrites existing styles on each mousemove, so no
    luck here.
  - Only set tooltip = true for both layers. This shows both tooltips
    together and is not exactly the desired behavior. Also attempted
    updating vis.tooltip in onSubLayer change, cartodb appears to not
    respect this change