### PR TITLE
Additional bugfixes

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -80,6 +80,10 @@
         <script src="scripts/map/area-analysis-control-directive.js"></script>
         <script src="scripts/brand/module.js"></script>
         <script src="scripts/brand/brand-directive.js"></script>
+        <script src="scripts/geo/module.js"></script>
+        <script src="scripts/geo/area-service.js"></script>
+        <script src="scripts/geo/geo-service.js"></script>
+        <script src="scripts/geo/state-abbrev-constant.js"></script>
         <script src="scripts/geocoder/module.js"></script>
         <script src="scripts/geocoder/geocoder-service.js"></script>
         <script src="scripts/museum/module.js"></script>
@@ -93,9 +97,7 @@
         <script src="scripts/acs/acs-service.js"></script>
         <script src="scripts/acs/acs-graphs.js"></script>
         <script src="scripts/util/module.js"></script>
-        <script src="scripts/util/area-service.js"></script>
         <script src="scripts/util/util-service.js"></script>
-        <script src="scripts/util/state-abbrev-constant.js"></script>
         <script src="scripts/views/footer/module.js"></script>
         <script src="scripts/views/footer/footer-directive.js"></script>
         <script src="scripts/views/home/module.js"></script>

--- a/app/scripts/geo/area-service.js
+++ b/app/scripts/geo/area-service.js
@@ -87,7 +87,7 @@
         }
     }
 
-    angular.module('imls.util')
+    angular.module('imls.geo')
     .service('Area', Area);
 
 })();

--- a/app/scripts/geo/geo-service.js
+++ b/app/scripts/geo/geo-service.js
@@ -1,0 +1,40 @@
+(function () {
+    'use strict';
+
+    /** @ngInject */
+    function Geo() {
+        var module = {
+            extent: extent
+        };
+        return module;
+
+        function extent(list) {
+            if (!(list && list.length)) {
+                return null;
+            }
+            var minLat = null;
+            var maxLat = null;
+            var minLon = null;
+            var maxLon = null;
+            angular.forEach(list, function (m) {
+                if (_.isNumber(m.latitude) && (m.latitude < minLat || minLat === null)) {
+                    minLat = m.latitude;
+                }
+                if (_.isNumber(m.latitude) && (m.latitude > maxLat || maxLat === null)) {
+                    maxLat = m.latitude;
+                }
+                if (_.isNumber(m.longitude) && (m.longitude < minLon || minLon === null)) {
+                    minLon = m.longitude;
+                }
+                if (_.isNumber(m.longitude) && (m.longitude > maxLon || maxLon === null)) {
+                    maxLon = m.longitude;
+                }
+            });
+            return [[minLat, minLon], [maxLat, maxLon]];
+        }
+    }
+
+    angular.module('imls.geo')
+    .service('Geo', Geo);
+
+})();

--- a/app/scripts/geo/geo-service.js
+++ b/app/scripts/geo/geo-service.js
@@ -8,6 +8,10 @@
         };
         return module;
 
+        /**
+         * Takes array of objects with latitude and longitude properties, and generates
+         * an extent of the form [[minLat, minLon], [maxLat, maxLon]];
+         */
         function extent(list) {
             if (!(list && list.length)) {
                 return null;
@@ -30,6 +34,9 @@
                     maxLon = m.longitude;
                 }
             });
+            if (minLat === null || maxLat === null || minLon === null || maxLon === null) {
+                return null;
+            }
             return [[minLat, minLon], [maxLat, maxLon]];
         }
     }

--- a/app/scripts/geo/module.js
+++ b/app/scripts/geo/module.js
@@ -1,0 +1,7 @@
+
+(function () {
+    'use strict';
+
+    angular.module('imls.geo', []);
+
+})();

--- a/app/scripts/geo/state-abbrev-constant.js
+++ b/app/scripts/geo/state-abbrev-constant.js
@@ -63,7 +63,7 @@
         'wyoming': 'WY'
     };
 
-    angular.module('imls.util')
+    angular.module('imls.geo')
     .constant('StateAbbrev', StateAbbrev);
 
 })();

--- a/app/scripts/map/area-analysis-control-directive.js
+++ b/app/scripts/map/area-analysis-control-directive.js
@@ -76,8 +76,6 @@
 
         function onStartDrawPolygon() {
             clearDrawHandler();
-            addCustomRadiusOption();
-            ctl.acsRadius = -1;
             var polygonDrawOptions = {};
             drawHandler = new L.Draw.Polygon(map, polygonDrawOptions);
             drawHandler.enable();
@@ -87,8 +85,6 @@
 
         function onStartDrawCircle() {
             clearDrawHandler();
-            addCustomRadiusOption();
-            ctl.acsRadius = -1;
             var circleDrawOptions = {};
             drawHandler = new L.Draw.Circle(map, circleDrawOptions);
             drawHandler.enable();
@@ -97,6 +93,7 @@
 
         function addCustomRadiusOption() {
             if (!_.find(ctl.acsRadiusOptions, function (option) { return option.value === CUSTOM_RADIUS_VALUE; })) {
+                ctl.acsRadius = CUSTOM_RADIUS_VALUE;
                 ctl.acsRadiusOptions.splice(0, 0, { value: CUSTOM_RADIUS_VALUE, label: 'Custom' });
             }
         }
@@ -112,9 +109,11 @@
             if (event.layerType === 'polygon') {
                 var points = layer.toGeoJSON().geometry.coordinates[0];
                 setArea(Area.polygon([points]));
+                addCustomRadiusOption();
             } else if (event.layerType === 'circle') {
                 var radius = layer.getRadius();
                 setArea(Area.circle(radius));
+                addCustomRadiusOption();
             }
 
             $scope.$emit('imls:area-analysis-control:draw:complete', event);

--- a/app/scripts/map/area-analysis-control-directive.js
+++ b/app/scripts/map/area-analysis-control-directive.js
@@ -64,17 +64,18 @@
         }
 
         function onDrawCancel() {
-            drawHandler.disable();
-            drawHandler = null;
+            clearDrawHandler();
         }
 
         function _onRadiusChanged() {
+            clearDrawHandler();
             clearCustomRadiusOption();
             setArea(Area.circle(ctl.acsRadius));
             $scope.$emit('imls:area-analysis-control:radius:changed', ctl.acsRadius);
         }
 
         function onStartDrawPolygon() {
+            clearDrawHandler();
             addCustomRadiusOption();
             ctl.acsRadius = -1;
             var polygonDrawOptions = {};
@@ -85,6 +86,7 @@
         }
 
         function onStartDrawCircle() {
+            clearDrawHandler();
             addCustomRadiusOption();
             ctl.acsRadius = -1;
             var circleDrawOptions = {};
@@ -127,6 +129,13 @@
                 decimalPlaces = 1;
             }
             ctl.area = $filter('number')(areaMiles, decimalPlaces);
+        }
+
+        function clearDrawHandler() {
+            if (drawHandler) {
+                drawHandler.disable();
+                drawHandler = null;
+            }
         }
     }
 

--- a/app/scripts/map/module.js
+++ b/app/scripts/map/module.js
@@ -2,6 +2,7 @@
     'use strict';
 
     angular.module('imls.map', [
-        'imls.config'
+        'imls.config',
+        'imls.geo'
     ]);
 })();

--- a/app/scripts/museum/module.js
+++ b/app/scripts/museum/module.js
@@ -3,7 +3,8 @@
 
     angular.module('imls.museum', [
         'imls.util',
-        'imls.config'
+        'imls.config',
+        'imls.geo'
     ]);
 
 })();

--- a/app/scripts/museum/museum-service.js
+++ b/app/scripts/museum/museum-service.js
@@ -115,7 +115,9 @@
                     if (k === 'gstate' && v.length !== 2) {
                         v = getStateAbbrev(v);
                     }
-                    return Util.strFormat('{k} ILIKE \'%{v}%\'', {k: k, v: v.replace('\'', '\'\'')});
+                    var comparator = k === 'gzip' ? '{v}%' : '{v}';
+                    var value = Util.strFormat(comparator, {v: v.replace('\'', '\'\'')});
+                    return Util.strFormat('{k} ILIKE \'{value}\'', {k: k, value: value});
                 })
                 .value();
             if (whereArray.length < 1) {

--- a/app/scripts/util/util-service.js
+++ b/app/scripts/util/util-service.js
@@ -17,7 +17,7 @@
         return module;
 
         function makeRequest(sql, query) {
-            $log.info(query);
+            $log.debug(query);
             var dfd = $q.defer();
             sql.execute(query).done(function (data) {
                 dfd.resolve(data.rows);

--- a/app/scripts/views/home/module.js
+++ b/app/scripts/views/home/module.js
@@ -31,6 +31,7 @@
         'smart-table',
         'ui.router',
         'ui.bootstrap',
+        'imls.geo',
         'imls.geocoder',
         'imls.museum',
         'imls.brand',

--- a/app/scripts/views/home/search-controller.js
+++ b/app/scripts/views/home/search-controller.js
@@ -97,21 +97,21 @@
             if (!(museumList && museumList.length)) {
                 return null;
             }
-            var minLat = museumList[0].latitude;
-            var maxLat = museumList[0].latitude;
-            var minLon = museumList[0].longitude;
-            var maxLon = museumList[0].longitude;
+            var minLat = null;
+            var maxLat = null;
+            var minLon = null;
+            var maxLon = null;
             angular.forEach(museumList, function (m) {
-                if (m.latitude < minLat) {
+                if (_.isNumber(m.latitude) && (m.latitude < minLat || minLat === null)) {
                     minLat = m.latitude;
                 }
-                if (m.latitude > maxLat) {
+                if (_.isNumber(m.latitude) && (m.latitude > maxLat || maxLat === null)) {
                     maxLat = m.latitude;
                 }
-                if (m.longitude < minLon) {
+                if (_.isNumber(m.longitude) && (m.longitude < minLon || minLon === null)) {
                     minLon = m.longitude;
                 }
-                if (m.longitude > maxLon) {
+                if (_.isNumber(m.longitude) && (m.longitude > maxLon || maxLon === null)) {
                     maxLon = m.longitude;
                 }
             });

--- a/app/scripts/views/home/search-controller.js
+++ b/app/scripts/views/home/search-controller.js
@@ -3,7 +3,7 @@
 
     /** @ngInject */
     function SearchController($log, $q, $scope, $timeout, $modal, $stateParams,
-                              Config, Museum) {
+                              Config, Geo, Museum) {
         var LOADING_TIMEOUT_MS = 300;
         var SEARCH_DIST_METERS = 1609.34;  // 1 mile
 
@@ -64,7 +64,7 @@
             func(params).then(function (rows) {
                 if (rows.length) {
                     ctl.list = rows;
-                    var extent = extentForList(ctl.list);
+                    var extent = Geo.extent(ctl.list);
                     homeCtl.getMap().then(function (map) {
                         map.fitBounds(extent);
                     });
@@ -93,30 +93,6 @@
             });
         }
 
-        function extentForList(museumList) {
-            if (!(museumList && museumList.length)) {
-                return null;
-            }
-            var minLat = null;
-            var maxLat = null;
-            var minLon = null;
-            var maxLon = null;
-            angular.forEach(museumList, function (m) {
-                if (_.isNumber(m.latitude) && (m.latitude < minLat || minLat === null)) {
-                    minLat = m.latitude;
-                }
-                if (_.isNumber(m.latitude) && (m.latitude > maxLat || maxLat === null)) {
-                    maxLat = m.latitude;
-                }
-                if (_.isNumber(m.longitude) && (m.longitude < minLon || minLon === null)) {
-                    minLon = m.longitude;
-                }
-                if (_.isNumber(m.longitude) && (m.longitude > maxLon || maxLon === null)) {
-                    maxLon = m.longitude;
-                }
-            });
-            return [[minLat, minLon], [maxLat, maxLon]];
-        }
     }
 
     angular.module('imls.views.home')

--- a/app/scripts/views/museum/museum-controller.js
+++ b/app/scripts/views/museum/museum-controller.js
@@ -74,7 +74,7 @@
                 ctl.nearbyInState = response;
             });
             addLocationMarker({x: ctl.museum.longitude, y: ctl.museum.latitude});
-            $log.info(ctl.museum);
+            $log.debug(ctl.museum);
             onRadiusChanged();
         }
 

--- a/app/scripts/views/museum/museum-controller.js
+++ b/app/scripts/views/museum/museum-controller.js
@@ -6,7 +6,7 @@
      */
     /* ngInject */
     function MuseumController($filter, $log, $scope, $state, $stateParams, $timeout, $window, resize,
-                              Config, ACS, ACSGraphs, MapStyle, Museum, Area) {
+                              Config, ACS, ACSGraphs, MapStyle, Museum) {
         var ctl = this;
 
         var LOAD_TIMEOUT_MS = 300;

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -44,6 +44,8 @@ module.exports = function(config) {
       'app/scripts/affix/*.js',
       'app/scripts/brand/module.js',
       'app/scripts/brand/*.js',
+      'app/scripts/geo/module.js',
+      'app/scripts/geo/*.js',
       'app/scripts/geocoder/module.js',
       'app/scripts/geocoder/*.js',
       'app/scripts/museum/module.js',

--- a/test/spec/geo/geo-service.spec.js
+++ b/test/spec/geo/geo-service.spec.js
@@ -1,0 +1,82 @@
+'use strict';
+
+describe('imls.geo: Geo', function () {
+
+    beforeEach(module('imls.geo'));
+
+    var Geo;
+
+    var testList1 = [{
+        latitude: 10,
+        longitude: 10
+    }, {
+        latitude: 5,
+        longitude: 20
+    }, {
+        latitude: 30,
+        longitude: 30
+    }];
+    var extent1 = [[5, 10], [30, 30]];
+
+    var testList2 = [{
+        latitude: null,
+        longitude: null
+    }, {
+        latitude: 5,
+        longitude: 20
+    }, {
+        latitude: 30,
+        longitude: 30
+    }];
+    var extent2 = [[5, 20], [30, 30]];
+
+    var testList3 = [{
+        latitude: null,
+        longitude: null
+    }, {
+        longitude: 20
+    }, {
+        latitude: 30
+    }];
+    var extent3 = [[30, 20], [30, 20]];
+
+    var testList4 = [{
+        latitude: null,
+        longitude: null
+    }, {
+        longitude: 20
+    }, {
+        longitude: 10
+    }];
+    var extent4 = null;
+
+    beforeEach(inject(function (_Geo_) {
+        Geo = _Geo_;
+    }));
+
+    describe('Geo.extent() should return the proper extents', function () {
+
+        it('should return null if anything other than a list with at least one value is passed', function () {
+            expect(Geo.extent()).toBeNull();
+            expect(Geo.extent(null)).toBeNull();
+            expect(Geo.extent([])).toBeNull();
+            expect(Geo.extent({})).toBeNull();
+        });
+
+        it('should return the proper extent', function () {
+            expect(Geo.extent(testList1)).toEqual(extent1);
+        });
+
+        it('should return the proper extent when some properties are null', function () {
+            expect(Geo.extent(testList2)).toEqual(extent2);
+        });
+
+        it('should return the proper extent when some properties are missing or null', function () {
+            expect(Geo.extent(testList3)).toEqual(extent3);
+        });
+
+        it('should return null if we never find a valid latitude', function () {
+            expect(Geo.extent(testList4)).toEqual(extent4);
+        });
+    });
+});


### PR DESCRIPTION
This fixes three issues:
1. Missing latitude/longitude values in the returned museum list could cause an invalid extent
2. Searching city/state by `ILIKE '%{value}%'` caused erroneous matches, such as in the case of 'NEW YORK' vs 'NEW YORK MILLS'. Switched to `ILIKE '{value}'` on city/state and `ILIKE '{value}%'` on zip to handle the optional 4 digit zip suffix.
3. Old draw objects are now properly cleared when the area control buttons are clicked while in drawing mode.

Added tests to ensure there aren't any breaking cases left for Geo.extent.